### PR TITLE
Add new button view layer for SwiftUI and UIKit

### DIFF
--- a/Sources/Core/View/SwiftUI/SparkButton+InitExtension.swift
+++ b/Sources/Core/View/SwiftUI/SparkButton+InitExtension.swift
@@ -1,0 +1,321 @@
+//
+//  SparkButton+InitExtension.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 16/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+
+public extension SparkButton where Content == EmptyView {
+
+    // MARK: - Initialization
+
+    /// Creates a button with a text label.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the button.
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton("Submit") {
+    ///     // Your action
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.main)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void
+    ) where Label == Text, ImageLabel == EmptyView {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: { Text(title) },
+            image: { EmptyView() }
+        )
+    }
+
+    /// Creates a button with a text label and an icon.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the button.
+    ///   - image: The icon image to display alongside the text.
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     "Save",
+    ///     image: Image(systemName: "checkmark")
+    /// ) {
+    ///     // Your action
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.support)
+    /// .sparkButtonAlignment(.leadingImage)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        image: Image,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void
+    ) where Label == Text, ImageLabel == SparkButtonImage {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: { Text(title) },
+            image: { SparkButtonImage(image: image) }
+        )
+    }
+
+    /// Creates an icon-only button.
+    ///
+    /// - Parameters:
+    ///   - image: The icon image to display.
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(Image(systemName: "heart.fill")) {
+    ///     // Your action
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.support)
+    /// .sparkButtonSize(.small)
+    /// ```
+    ///
+    init(
+        _ image: Image,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void
+    ) where Label == EmptyView, ImageLabel == SparkButtonImage {
+        self.init(
+            type: .iconButton,
+            role: role,
+            action: action,
+            label: { EmptyView() },
+            image: { SparkButtonImage(image: image) }
+        )
+    }
+
+    /// Creates a button with a custom label.
+    ///
+    /// Use this initializer when you need complete control over the button's label content.
+    ///
+    /// - Parameters:
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///   - label: A view builder that creates the button's label.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(action: {
+    ///     // Your action
+    /// }) {
+    ///     VStack {
+    ///         Text("Custom")
+    ///         Text("Label")
+    ///     }
+    /// }
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        label: @escaping () -> Label
+    ) where ImageLabel == EmptyView {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: label,
+            image: { EmptyView() }
+        )
+    }
+
+    /// Creates a button with a custom label and an icon.
+    ///
+    /// Use this initializer when you need a custom label alongside an icon.
+    ///
+    /// - Parameters:
+    ///   - image: The icon image to display alongside the label.
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///   - label: A view builder that creates the button's label.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     Image(systemName: "star.fill"),
+    ///     action: {
+    ///         // Your action
+    ///     }
+    /// ) {
+    ///     VStack {
+    ///         Text("Rate")
+    ///         Text("5 stars")
+    ///     }
+    /// }
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        _ image: Image,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        label: @escaping () -> Label
+    ) where ImageLabel == SparkButtonImage {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: label,
+            image: { SparkButtonImage(image: image) }
+        )
+    }
+
+    /// Creates a button with a text label and a custom image view.
+    ///
+    /// Use this initializer when you need full control over the image rendering,
+    /// such as applying custom animations or effects to the icon.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the button.
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     "Notify",
+    ///     action: {
+    ///         // Your action
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "bell.fill"))
+    ///             .scaleEffect(self.isAnimating ? 1.2 : 1.0)
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        image: @escaping () -> ImageLabel
+    ) where Label == Text {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: { Text(title) },
+            image: image
+        )
+    }
+
+    /// Creates an icon-only button with a custom image view.
+    ///
+    /// Use this initializer when you need full control over the image rendering,
+    /// such as applying custom animations or effects to the icon.
+    ///
+    /// - Parameters:
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     action: {
+    ///         // Your action
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "bell.fill"))
+    ///             .rotationEffect(.degrees(self.rotation))
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        image: @escaping () -> ImageLabel
+    ) where Label == EmptyView {
+        self.init(
+            type: .iconButton,
+            role: role,
+            action: action,
+            label: { EmptyView() },
+            image: image
+        )
+    }
+
+    /// Creates a button with a custom label and a custom image view.
+    ///
+    /// Use this initializer when you need full control over both the label and image rendering,
+    /// such as applying custom animations or effects.
+    ///
+    /// - Parameters:
+    ///   - role: An optional semantic role that describes the button's purpose. Optional. Default is *nil*.
+    ///   - action: The action to perform when the button is tapped.
+    ///   - label: A view builder that creates the button's label.
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.   
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     action: {
+    ///         // Your action
+    ///     },
+    ///     label: {
+    ///         Text("Custom Label")
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "star.fill"))
+    ///             .scaleEffect(self.isAnimating ? 1.2 : 1.0)         
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        label: @escaping () -> Label,
+        image: @escaping () -> ImageLabel
+    ) {
+        self.init(
+            type: .button,
+            role: role,
+            action: action,
+            label: label,
+            image: image
+        )
+    }
+}

--- a/Sources/Core/View/SwiftUI/SparkButton+InitMenuExtension.swift
+++ b/Sources/Core/View/SwiftUI/SparkButton+InitMenuExtension.swift
@@ -1,0 +1,332 @@
+//
+//  SparkButton+InitMenuExtension.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 16/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+
+public extension SparkButton {
+
+    // MARK: - Initialization
+
+    /// Creates a menu button with a text label.
+    ///
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the menu button.
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton("Options") {
+    ///     Button("Edit") { }
+    ///     Button("Delete") { }
+    ///     Button("Share") { }
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.main)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        @ViewBuilder content: @escaping () -> Content
+    ) where Label == Text, ImageLabel == EmptyView {
+        self.init(
+            type: .button,
+            label: { Text(title) },
+            image: { EmptyView() },
+            content: content
+        )
+    }
+
+    /// Creates a menu button with a text label and an icon.
+    ///
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the menu button.
+    ///   - image: The icon image to display alongside the text.
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     "Actions",
+    ///     image: Image(systemName: "ellipsis.circle")
+    /// ) {
+    ///     Button("Edit") { }
+    ///     Button("Delete") { }
+    ///     Button("Share") { }
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.support)
+    /// .sparkButtonAlignment(.leadingImage)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        image: Image,
+        @ViewBuilder content: @escaping () -> Content
+    ) where Label == Text, ImageLabel == SparkButtonImage {
+        self.init(
+            type: .button,
+            label: { Text(title) },
+            image: { SparkButtonImage(image: image) },
+            content: content
+        )
+    }
+
+    /// Creates an icon-only menu button.
+    ///
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - image: The icon image to display.
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(Image(systemName: "ellipsis")) {
+    ///     Button("Edit") { }
+    ///     Button("Delete") { }
+    ///     Button("Share") { }
+    /// }
+    /// .sparkTheme(self.theme)
+    /// .sparkButtonIntent(.support)
+    /// .sparkButtonSize(.small)
+    /// ```
+    ///
+    init(
+        _ image: Image,
+        @ViewBuilder content: @escaping () -> Content
+    ) where Label == EmptyView, ImageLabel == SparkButtonImage {
+        self.init(
+            type: .iconButton,
+            label: { EmptyView() },
+            image: { SparkButtonImage(image: image) },
+            content: content
+        )
+    }
+
+    /// Creates a menu button with a custom label.
+    ///
+    /// Use this initializer when you need complete control over the menu button's label content.
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///   - label: A view builder that creates the button's label.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     content: {
+    ///         Button("Edit") { }
+    ///         Button("Delete") { }
+    ///     },
+    ///     label: {
+    ///         VStack {
+    ///             Text("Custom")
+    ///             Text("Menu")
+    ///         }
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        @ViewBuilder content: @escaping () -> Content,
+        label: @escaping () -> Label
+    ) where ImageLabel == EmptyView {
+        self.init(
+            type: .button,
+            label: label,
+            image: { EmptyView() },
+            content: content
+        )
+    }
+
+    /// Creates a menu button with a custom label and an icon.
+    ///
+    /// Use this initializer when you need a custom label alongside an icon.
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - image: The icon image to display alongside the label.
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///   - label: A view builder that creates the button's label.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     Image(systemName: "star.fill"),
+    ///     content: {
+    ///         Button("Rate 5 stars") { }
+    ///         Button("Rate 4 stars") { }
+    ///         Button("Rate 3 stars") { }
+    ///     },
+    ///     label: {
+    ///         VStack {
+    ///             Text("Rate")
+    ///             Text("this item")
+    ///         }
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        _ image: Image,
+        @ViewBuilder content: @escaping () -> Content,
+        label: @escaping () -> Label
+    ) where ImageLabel == SparkButtonImage {
+        self.init(
+            type: .button,
+            label: label,
+            image: { SparkButtonImage(image: image) },
+            content: content
+        )
+    }
+
+    /// Creates a menu button with a text label and a custom image view.
+    ///
+    /// Use this initializer when you need full control over the image rendering,
+    /// such as applying custom animations or effects to the icon.
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - title: The text label to display on the menu button.
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     "Notify",
+    ///     content: {
+    ///         Button("Enable") { }
+    ///         Button("Disable") { }
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "bell.fill"))
+    ///             .scaleEffect(self.isAnimating ? 1.2 : 1.0)
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        _ title: String,
+        @ViewBuilder content: @escaping () -> Content,
+        image: @escaping () -> ImageLabel
+    ) where Label == Text {
+        self.init(
+            type: .button,
+            label: { Text(title) },
+            image: image,
+            content: content
+        )
+    }
+
+    /// Creates an icon-only menu button with a custom image view.
+    ///
+    /// Use this initializer when you need full control over the image rendering,
+    /// such as applying custom animations or effects to the icon.
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     content: {
+    ///         Button("Edit") { }
+    ///         Button("Delete") { }
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "ellipsis"))
+    ///             .rotationEffect(.degrees(self.rotation))
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        @ViewBuilder content: @escaping () -> Content,
+        image: @escaping () -> ImageLabel
+    ) where Label == EmptyView {
+        self.init(
+            type: .iconButton,
+            label: { EmptyView() },
+            image: image,
+            content: content
+        )
+    }
+
+    /// Creates a menu button with a custom label and a custom image view.
+    ///
+    /// Use this initializer when you need full control over both the label and image rendering,
+    /// such as applying custom animations or effects.
+    /// This initializer creates a button that displays a menu with a list of menu items when tapped,
+    /// similar to the native SwiftUI Menu component.
+    ///
+    /// - Parameters:
+    ///   - content: A view builder that creates the menu content (a list of buttons).
+    ///   - label: A view builder that creates the button's label.
+    ///   - image: A view builder that creates the custom image content.
+    ///   Use the ``SparkButtonImage``  to implement the image.
+    ///
+    /// ## Example of usage
+    ///
+    /// ```swift
+    /// SparkButton(
+    ///     content: {
+    ///         Button("Option 1") { }
+    ///         Button("Option 2") { }
+    ///     },
+    ///     label: {
+    ///         Text("Custom Label")
+    ///     },
+    ///     image: {
+    ///         SparkButtonImage(image: Image(systemName: "star.fill"))
+    ///             .opacity(self.isHighlighted ? 1.0 : 0.5)
+    ///     }
+    /// )
+    /// .sparkTheme(self.theme)
+    /// ```
+    ///
+    init(
+        @ViewBuilder content: @escaping () -> Content,
+        label: @escaping () -> Label,
+        image: @escaping () -> ImageLabel
+    ) {
+        self.init(
+            type: .button,
+            label: label,
+            image: image,
+            content: content
+        )
+    }
+}

--- a/Sources/Core/View/SwiftUI/SparkButton.swift
+++ b/Sources/Core/View/SwiftUI/SparkButton.swift
@@ -1,0 +1,408 @@
+//
+//  SparkButton.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 24/02/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+@_spi(SI_SPI) import SparkCommon
+import SparkComponentSpinner
+
+/// Spark Buttons are clickable elements used to trigger actions.
+///
+/// Buttons communicate calls to action to the user and allow users
+/// to interact with pages in a variety of ways.
+/// Button labels express what action will occur when the user interacts with it.
+///
+/// ## Example of usage
+///
+/// ### Text Only Button
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///
+///     var body: some View {
+///         SparkButton("Click Me") {
+///             // Your action
+///         }
+///         .sparkTheme(self.theme)
+///         .sparkButtonIntent(.main)
+///         .sparkButtonVariant(.filled)
+///         .sparkButtonSize(.medium)
+///     }
+/// }
+/// ```
+///
+/// ### Button with Icon
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///
+///     var body: some View {
+///         SparkButton(
+///             "Save",
+///             image: Image(systemName: "checkmark")
+///         ) {
+///             // Your action
+///         }
+///         .sparkTheme(self.theme)
+///         .sparkButtonIntent(.support)
+///         .sparkButtonVariant(.outlined)
+///         .sparkButtonSize(.medium)
+///         .sparkButtonAlignment(.leadingImage)
+///     }
+/// }
+/// ```
+///
+/// ### Icon Only Button
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///
+///     var body: some View {
+///         SparkButton(Image(systemName: "heart.fill")) {
+///             // Your action
+///         }
+///         .sparkTheme(self.theme)
+///         .sparkButtonIntent(.support)
+///         .sparkButtonVariant(.ghost)
+///         .sparkButtonSize(.small)
+///     }
+/// }
+/// ```
+///
+/// ### Custom Label Button
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///
+///     var body: some View {
+///         SparkButton(action: {
+///             // Your action
+///         }) {
+///             VStack {
+///                 Text("Custom")
+///                 Text("Label")
+///             }
+///         }
+///         .sparkTheme(self.theme)
+///         .sparkButtonIntent(.main)
+///         .sparkButtonVariant(.tinted)
+///         .sparkButtonSize(.large)
+///     }
+/// }
+/// ```
+///
+/// ### Loading State
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///     @State private var isLoading = false
+///
+///     var body: some View {
+///         SparkButton("Submit") {
+///             self.isLoading = true
+///             // Perform async operation
+///         }
+///         .sparkTheme(self.theme)
+///         .sparkButtonIntent(.main)
+///         .sparkButtonVariant(.filled)
+///         .sparkButtonIsLoading(self.isLoading)
+///     }
+/// }
+/// ```
+///
+/// ### Max width State
+///
+/// ```swift
+/// struct MyView: View {
+///     let theme: SparkTheming.Theme = MyTheme()
+///     @State private var isLoading = false
+///
+///     var body: some View {
+///         SparkButton("Share") {
+///             // Your action
+///          }
+///         .sparkTheme(self.theme)
+///         .sparkButtonMaxWidth(.infinity)
+///     }
+/// }
+/// ```
+///
+/// ## Menu
+///
+/// Button can also be a native **menu** :
+///
+/// ```swift
+/// SparkButton("Options") {
+///     Button("Edit") { }
+///     Button("Delete") { }
+///     Button("Share") { }
+/// }
+/// .sparkTheme(self.theme)
+/// .sparkButtonIntent(.main)
+/// ```
+///
+/// ## EnvironmentValues
+///
+/// This component uses some EnvironmentValues:
+/// - **theme**: ``sparkTheme(_:)`` (View extension)
+/// - **intent**: ``sparkButtonIntent(_:)`` (View extension)
+/// - **variant**: ``sparkButtonVariant(_:)`` (View extension)
+/// - **shape**: ``sparkButtonShape(_:)`` (View extension)
+/// - **size**: ``sparkButtonSize(_:)`` (View extension)
+/// - **alignment**: ``sparkButtonAlignment(_:)`` (View extension)
+/// - **contentVisibility**: ``sparkButtonContentVisibility(_:)`` (View extension)
+/// - **hasFeedback**: ``sparkButtonHasFeedback(_:)`` (View extension)
+/// - **isLoading**: ``sparkButtonIsLoading(_:)`` (View extension)
+/// - **maxWidth**: ``sparkButtonMaxWidth(_:)`` (View extension)
+/// - **removeStyles**: ``sparkButtonRemoveStyles(_:)`` (View extension)
+///
+/// > If these values are not set, default values will be applied.
+///
+/// > **YOU MUST PROVIDE ``sparkTheme(_:)``**
+///
+/// ## Accessibility
+///
+/// SparkButton automatically supports:
+/// - VoiceOver with proper button traits
+/// - Dynamic Type up to xxxLarge
+/// - Large Content Viewer for accessibility
+/// - Haptic feedback on button press
+///
+/// If you only provide a image, you must set the **accessibilityLabel**.
+///
+/// ## Rendering
+///
+/// ### Title
+///
+/// ![Button rendering.](button_title.png)
+///
+/// ### Icon only
+///
+/// ![Button rendering.](button_icon.png)
+///
+/// ### All content (image + title)
+///
+/// ![Button rendering.](button_all.png)
+///
+public struct SparkButton<Label, ImageLabel, Content>: View where Label: View, ImageLabel: View, Content: View {
+
+    // MARK: - Properties
+
+    private var image: () -> ImageLabel
+    private var label: () -> Label
+    private var content: () -> Content
+    private var role: ButtonRole?
+    private var action: (() -> Void)?
+
+    @Environment(\.theme) private var theme
+    @Environment(\.buttonAlignment) private var alignment
+    @Environment(\.buttonContentVisibility) private var contentVisibility
+    @Environment(\.buttonHasFeedback) private var hasFeedback
+    @Environment(\.buttonIntent) private var intent
+    @Environment(\.buttonIsLoading) private var isLoading
+    @Environment(\.buttonMaxWidth) private var maxWidth
+    @Environment(\.buttonRemoveStyles) private var removeStyles
+    @Environment(\.buttonShape) private var shape
+    @Environment(\.buttonSize) private var size
+    @Environment(\.buttonVariant) private var variant
+    @Environment(\.isEnabled) private var isEnabled
+
+    private let type: ButtonType
+
+    @StateObject private var viewModel = ButtonViewModel()
+
+    @State private var feedbackID: UUID = UUID()
+
+    // MARK: - Initialization
+
+    init(
+        type: ButtonType,
+        role: ButtonRole? = nil,
+        action: @escaping @MainActor () -> Void,
+        label: @escaping () -> Label,
+        image: @escaping () -> ImageLabel
+    ) where Content == EmptyView {
+        self.type = type
+        self.role = role
+        self.action = action
+        self.label = label
+        self.image = image
+        self.content = { EmptyView() }
+    }
+
+    init(
+        type: ButtonType,
+        label: @escaping () -> Label,
+        image: @escaping () -> ImageLabel,
+        content: @escaping () -> Content
+    ) {
+        self.type = type
+        self.role = nil
+        self.action = nil
+        self.label = label
+        self.image = image
+        self.content = content
+    }
+
+    // MARK: - View
+
+    public var body: some View {
+        self.button {
+            SparkHStack(spacing: self.viewModel.layout.horizontalSpacing) {
+                // Loading
+                if self.isLoading {
+                    SparkSpinner()
+                        .sparkSpinnerSize(.onButton)
+                        .sparkSpinnerIntent(.custom(self.viewModel.colors.tintColor))
+                }
+
+                // Content
+                if self.viewModel.showContent {
+                     self.buttonContent()
+                }
+            }
+            .sparkPadding(.horizontal, self.viewModel.layout.horizontalPadding)
+            .sparkFrame(
+                width: self.viewModel.sizes.isFixedWidth ? self.viewModel.sizes.width : nil,
+                height: self.viewModel.sizes.isFixedHeight ? self.viewModel.sizes.height : nil
+            )
+            .sparkFrame(minWidth: self.viewModel.sizes.width)
+            .frame(maxWidth: self.viewModel.sizes.isFixedWidth ? nil : self.maxWidth)
+            .frame(maxHeight: self.viewModel.sizes.maxHeight)
+            .background(self.viewModel.colors.backgroundColor)
+            .contentShape(Rectangle())
+            .sparkBorder(
+                width: self.viewModel.border.width,
+                radius: self.viewModel.border.radius,
+                colorToken: self.viewModel.colors.borderColor
+            )
+        }
+        .buttonStyle(PressedButtonStyle(
+            isPressed: self.$viewModel.isPressed
+        ))
+        .opacity(self.viewModel.dim)
+        .sparkSensoryFeedback(.impact, trigger: self.feedbackID)
+        .accessibilityIdentifier(ButtonAccessibilityIdentifier.button)
+        .accessibilityShowsLargeContentViewer() {
+            self.image()
+            self.label()
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        .onAppear() {
+            self.viewModel.setup(
+                theme: self.theme.value,
+                intent: self.intent,
+                variant: self.variant,
+                shape: self.shape,
+                size: self.size,
+                type: self.type,
+                contentVisibility: self.contentVisibility,
+                removeStyles: self.removeStyles,
+                isEnabled: self.isEnabled,
+                isLoading: self.isLoading
+            )
+        }
+        .onChange(of: self.theme) { theme in
+            self.viewModel.theme = theme.value
+        }
+        .onChange(of: self.intent) { intent in
+            self.viewModel.intent = intent
+        }
+        .onChange(of: self.variant) { variant in
+            self.viewModel.variant = variant
+        }
+        .onChange(of: self.shape) { shape in
+            self.viewModel.shape = shape
+        }
+        .onChange(of: self.size) { size in
+            self.viewModel.size = size
+        }
+        .onChange(of: self.contentVisibility) { contentVisibility in
+            self.viewModel.contentVisibility = contentVisibility
+        }
+        .onChange(of: self.removeStyles) { removeStyles in
+            self.viewModel.removeStyles = removeStyles
+        }
+        .onChange(of: self.type) { type in
+            self.viewModel.type = type
+        }
+        .onChange(of: self.isEnabled) { isEnabled in
+            self.viewModel.isEnabled = isEnabled
+        }
+        .onChange(of: self.isLoading) { isLoading in
+            self.viewModel.isLoading = isLoading
+        }
+    }
+
+    @ViewBuilder
+    private func button<V>(@ViewBuilder label: @escaping () -> V) -> some View where V: View {
+        if self.content().isEmptyView {
+            Button(
+                role: self.role,
+                action: {
+                    self.action?()
+
+                    // Play feedback only
+                    if self.hasFeedback {
+                        self.feedbackID = .init()
+                    }
+                },
+                label: label
+            )
+        } else {
+            Menu(
+                content: self.content,
+                label: label
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func buttonContent() -> some View {
+        let image = self.image()
+            .sparkFrame(
+                size: self.viewModel.sizes.imageSize,
+                alignment: .center
+            )
+            .foregroundStyle(self.viewModel.colors.tintColor)
+
+        let label = self.label()
+            .foregroundStyle(self.viewModel.colors.tintColor)
+            .font(self.viewModel.titleFontToken)
+            .transition(
+                .move(edge: self.alignment.isTrailingImage ? .leading : .trailing)
+                .combined(with: .opacity)
+            )
+            .fixedSize()
+
+        // Display the content from the current visibility
+        // and the position.
+        if self.alignment.isTrailingImage {
+            if self.contentVisibility.showLabel {
+                label
+            }
+
+            if self.contentVisibility.showImage {
+                image
+            }
+
+        } else {
+            if self.contentVisibility.showImage {
+                image
+            }
+
+            if self.contentVisibility.showLabel {
+                label
+            }
+        }
+    }
+}

--- a/Sources/Core/View/SwiftUI/SparkButtonImage.swift
+++ b/Sources/Core/View/SwiftUI/SparkButtonImage.swift
@@ -1,0 +1,97 @@
+//
+//  SparkButtonImage.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 16/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+
+/// A wrapper view for button images that ensures proper sizing and rendering.
+///
+/// Use `SparkButtonImage` when you need to provide a custom image view to ``SparkButton``
+/// with custom animations or effects. This view automatically applies the correct aspect ratio
+/// and resizing behavior for button icons.
+///
+/// ## Example of usage
+///
+/// ### Basic Usage
+///
+/// ```swift
+/// SparkButton(
+///     "Save",
+///     action: { }
+/// ) {
+///     SparkButtonImage(image: Image(systemName: "checkmark"))
+/// }
+/// ```
+///
+/// ### With Animation
+///
+/// ```swift
+/// struct MyView: View {
+///     @State private var scale: CGFloat = 1.0
+///
+///     var body: some View {
+///         SparkButton(
+///             "Animate",
+///             action: {
+///                 withAnimation {
+///                     self.scale = 1.5
+///                 }
+///             }
+///         ) {
+///             SparkButtonImage(image: Image(systemName: "star.fill"))
+///                 .scaleEffect(self.scale)
+///         }
+///         .sparkTheme(self.theme)
+///     }
+/// }
+/// ```
+///
+/// ### With Rotation Effect
+///
+/// ```swift
+/// struct MyView: View {
+///     @State private var rotation: Double = 0
+///
+///     var body: some View {
+///         SparkButton(
+///             action: {
+///                 withAnimation {
+///                     self.rotation += 180
+///                 }
+///             }
+///         ) {
+///             SparkButtonImage(image: Image(systemName: "arrow.clockwise"))
+///                 .rotationEffect(.degrees(self.rotation))
+///         }
+///         .sparkTheme(self.theme)
+///     }
+/// }
+/// ```
+///
+public struct SparkButtonImage: View {
+
+    // MARK: - Properties
+
+    let image: Image
+
+    // MARK: - Initialization
+
+    /// Creates a button image view.
+    ///
+    /// - Parameter image: The image to display in the button.
+    public init(image: Image) {
+        self.image = image
+    }
+
+    // MARK: - View
+
+    public var body: some View {
+        self.image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    }
+}

--- a/Sources/Core/View/SwiftUI/Style/SparkButtonStyle.swift
+++ b/Sources/Core/View/SwiftUI/Style/SparkButtonStyle.swift
@@ -1,0 +1,54 @@
+//
+//  SparkButtonStyle.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 20/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import SwiftUI
+
+/// A protocol that defines the visual appearance of a ``SparkButton``.
+///
+/// Conform to this protocol to create custom button styles that modify only the design
+/// and visual presentation of Spark buttons without altering their behavior or functionality.
+///
+/// Use the `sparkButtonStyle(_:)` modifier to apply your custom style to a button:
+///
+/// ```swift
+/// SparkButton("Submit") {
+///     // Your action
+/// }
+/// .sparkButtonStyle(MyCustomButtonStyle())
+/// ```
+///
+/// - Note: This protocol extends `ViewModifier`, allowing you to apply custom visual transformations
+///   to the button's content while preserving its interactive behavior.
+@MainActor @preconcurrency public protocol SparkButtonStyle: ViewModifier {
+
+    /// Gets the current body of the caller.
+    ///
+    /// `content` is a proxy for the view that will have the modifier
+    /// represented by `Self` applied to it.
+    @ViewBuilder @MainActor @preconcurrency func body(content: Self.Content) -> Self.Body
+}
+
+public extension View {
+
+    /// Sets the style for spark buttons within this view to a button style with a
+    /// custom appearance.
+    ///
+    /// Use this modifier to set a specific style for button instances
+    /// within a view:
+    ///
+    /// ```swift
+    /// SparkButton("Upload") {
+    ///     // Your action
+    /// }
+    /// .buttonStyle(.myCustomButtonStyle)
+    /// ```
+    ///
+    nonisolated func sparkButtonStyle<S>(_ style: S) -> some View where S: SparkButtonStyle {
+        self.modifier(style)
+    }
+}

--- a/Sources/Core/View/UIKit/Internal/ButtonUIImageView.swift
+++ b/Sources/Core/View/UIKit/Internal/ButtonUIImageView.swift
@@ -1,0 +1,110 @@
+//
+//  ButtonUIImageView.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 19/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+@_spi(SI_SPI) import SparkCommon
+import UIKit
+
+final class ButtonUIImageView: UIView {
+
+    // MARK: - Components
+
+     private(set) var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintAdjustmentMode = .normal
+        imageView.setContentCompressionResistancePriority(.required, for: .vertical)
+        imageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        imageView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        imageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return imageView
+    }()
+
+    // MARK: - Properties
+
+    var image: UIImage? {
+        get {
+            self.imageView.image
+        }
+        set {
+            self.imageView.image = newValue
+            self.isHidden = newValue == nil
+        }
+    }
+
+    @ScaledUIFrame private var imageSize: CGFloat = 0
+    private var imageHeightConstraint: NSLayoutConstraint?
+
+    // MARK: - Initialization
+
+    init() {
+        super.init(frame: .zero)
+
+        self.setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Setup
+
+    private func setupView() {
+        // Add subviews
+        self.addSubview(self.imageView)
+
+        // Setup constraints
+        self.setupConstraints()
+    }
+
+    // MARK: - Constraints
+
+    private func setupConstraints() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        self.setupImageViewConstraints()
+    }
+
+    private func setupImageViewConstraints() {
+        self.imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.imageHeightConstraint = self.imageView.heightAnchor.constraint(equalToConstant: .zero)
+
+        NSLayoutConstraint.activate([
+            self.imageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.imageView.widthAnchor.constraint(equalTo: self.imageView.heightAnchor),
+
+            self.widthAnchor.constraint(equalTo: self.imageView.widthAnchor),
+            self.heightAnchor.constraint(greaterThanOrEqualTo: self.imageView.heightAnchor)
+        ])
+    }
+
+    // MARK: - Update UI
+
+    func updateImageSize(_ size: CGFloat) {
+        self._imageSize = .init(
+            wrappedValue: size,
+            traitCollection: self.traitCollection
+        )
+        self.updateImageHeight()
+    }
+
+    private func updateImageHeight() {
+        self.imageHeightConstraint?.constant = self.imageSize
+        self.imageHeightConstraint?.isActive = true
+        self.setNeedsUpdateConstraints()
+    }
+
+    // MARK: - Trait Collection
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        self._imageSize.update(traitCollection: self.traitCollection)
+        self.updateImageHeight()
+    }
+}

--- a/Sources/Core/View/UIKit/Internal/ButtonUISpinner.swift
+++ b/Sources/Core/View/UIKit/Internal/ButtonUISpinner.swift
@@ -1,0 +1,86 @@
+//
+//  ButtonUISpinner.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 19/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import UIKit
+@_spi(SI_SPI) import SparkCommon
+import SparkTheming
+import SparkComponentSpinner
+
+final class ButtonUISpinner: UIView {
+
+    // MARK: - Components
+
+    private lazy var spinner: SparkUISpinner = {
+        let spinner = SparkUISpinner(theme: self.theme)
+        spinner.size = .onButton
+        return spinner
+    }()
+
+    // MARK: - Properties
+
+    var theme: any Theme {
+        didSet {
+            self.spinner.theme = self.theme
+        }
+    }
+
+    var intent: SpinnerIntent {
+        get {
+            self.spinner.intent
+        }
+        set {
+            self.spinner.intent = newValue
+        }
+    }
+
+    private var imageHeightConstraint: NSLayoutConstraint?
+
+    // MARK: - Initialization
+
+    init(theme: any Theme) {
+        self.theme = theme
+
+        super.init(frame: .zero)
+
+        self.setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Setup
+
+    private func setupView() {
+        // Add subviews
+        self.addSubview(self.spinner)
+
+        // Setup constraints
+        self.setupConstraints()
+    }
+
+    // MARK: - Constraints
+
+    private func setupConstraints() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        self.setupStepperViewConstraints()
+    }
+
+    private func setupStepperViewConstraints() {
+        self.spinner.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            self.spinner.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            self.spinner.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+
+            self.widthAnchor.constraint(greaterThanOrEqualTo: self.spinner.widthAnchor),
+            self.heightAnchor.constraint(greaterThanOrEqualTo: self.spinner.heightAnchor)
+        ])
+    }
+}

--- a/Sources/Core/View/UIKit/SparkUIButton.swift
+++ b/Sources/Core/View/UIKit/SparkUIButton.swift
@@ -1,0 +1,836 @@
+//
+//  SparkUIButton.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 18/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+import UIKit
+@_spi(SI_SPI) import SparkCommon
+import SparkTheming
+import SparkComponentSpinner
+import Combine
+
+/// Spark Buttons are clickable elements used to trigger actions.
+///
+/// Buttons communicate calls to action to the user and allow users
+/// to interact with pages in a variety of ways.
+/// Button labels express what action will occur when the user interacts with it.
+///
+/// ## Example of usage
+///
+/// ### Text Only Button
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme)
+/// button.setTitle("Click Me", for: .normal)
+/// button.intent = .main
+/// button.variant = .filled
+/// button.size = .medium
+/// button.addAction(UIAction { _ in
+///     // Your action
+/// }, for: .touchUpInside)
+/// ```
+///
+/// ### Button with Icon
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme)
+/// button.setTitle("Save", for: .normal)
+/// button.setImage(UIImage(systemName: "checkmark"), for: .normal)
+/// button.intent = .support
+/// button.variant = .outlined
+/// button.size = .medium
+/// button.alignment = .leadingImage
+/// ```
+///
+/// ### Icon Button
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme)
+/// button.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+/// button.intent = .support
+/// button.variant = .ghost
+/// button.size = .small
+/// ```
+///
+/// ### Loading State
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme)
+/// button.setTitle("Submit", for: .normal)
+/// button.isLoading = true
+/// ```
+///
+/// ### Content Visibility With Animation
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme)
+/// button.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+/// button.setTitle("Submit", for: .normal)
+/// button.setContentVisibility(.hideLabel, animated: true)
+/// ```
+///
+/// ## Accessibility
+///
+/// SparkUIButton automatically supports:
+/// - VoiceOver with proper button traits
+/// - Dynamic Type
+/// - Large Content Viewer for accessibility
+///
+/// If you only provide an image, you must set the **accessibilityLabel**.
+///
+/// ## Rendering
+///
+/// ### Title
+///
+/// ![Button rendering.](button_title.png)
+///
+/// ### Icon only
+///
+/// ![Button rendering.](button_icon.png)
+///
+/// ### All content (image + title)
+///
+/// ![Button rendering.](button_all.png)
+/// 
+public final class SparkUIButton: UIControl {
+
+    // MARK: - Components
+
+    private lazy var contentStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            self.spaceView1,
+            self.spinner,
+            self.titleLabel,
+            self._imageView,
+            self.spaceView2
+        ])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.isUserInteractionEnabled = false
+        return stackView
+    }()
+
+    private let spaceView1 = UIView()
+    private let spaceView2 = UIView()
+
+    private lazy var spinner: ButtonUISpinner = {
+        let spinner = ButtonUISpinner(theme: self.theme)
+        spinner.isHidden = true
+        return spinner
+    }()
+
+    private var _imageView: ButtonUIImageView = {
+        let imageView = ButtonUIImageView()
+        imageView.isHidden = true
+        return imageView
+    }()
+
+    /// The UIImageView used to display the button image.
+    public var imageView: UIImageView {
+        self._imageView.imageView
+    }
+
+    /// The UILabel used to display the button title.
+    ///
+    /// Please **do not set a text/attributedText** in this label but use
+    /// the ``setTitle(_:for:)`` and ``setAttributedTitle(_:for:)`` directly on the ``SparkUIButton``.
+    public private(set) var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.lineBreakMode = .byTruncatingMiddle
+        label.isHidden = true
+        return label
+    }()
+
+    // MARK: - Public Properties
+
+    /// The spark theme of the button.
+    public var theme: any Theme {
+        didSet {
+            self.viewModel.theme = self.theme
+            self.spinner.theme = self.theme
+        }
+    }
+
+    /// The intent of the button.
+    /// Check the ``ButtonIntent`` to see the **default** value.
+    public var intent: ButtonIntent = .default {
+        didSet {
+            self.viewModel.intent = self.intent
+        }
+    }
+
+    /// The variant of the button.
+    /// Check the ``ButtonVariant`` to see the **default** value.
+    public var variant: ButtonVariant = .default {
+        didSet {
+            self.viewModel.variant = self.variant
+        }
+    }
+
+    /// The shape of the button.
+    /// Check the ``ButtonShape`` to see the **default** value.
+    public var shape: ButtonShape = .default {
+        didSet {
+            self.viewModel.shape = self.shape
+        }
+    }
+
+    /// The size of the button.
+    /// Check the ``ButtonSize`` to see the **default** value.
+    public var size: ButtonSize = .default {
+        didSet {
+            self.viewModel.size = self.size
+        }
+    }
+
+    /// The alignment of the button (image position relative to text).
+    /// Check the ``ButtonAlignment`` to see the **default** value.
+    public var alignment: ButtonAlignment = .default {
+        didSet {
+            self.updateAlignment()
+        }
+    }
+
+    /// The content visibility of the button.
+    /// Check the ``ButtonContentVisibility`` to see the **default** value.
+    public var contentVisibility: ButtonContentVisibility = .default {
+        didSet {
+            self.viewModel.contentVisibility = self.contentVisibility
+        }
+    }
+
+    /// Remove the styles (*border*, *radius*, *height*, ...) on the Button if the value is **true**.
+    /// The **default** value is **false**.
+    public var removeStyles: Bool = false {
+        didSet {
+            self.viewModel.removeStyles = self.removeStyles
+        }
+    }
+
+    /// A Boolean value that determines whether the button action play a feedback.
+    /// The **default** value is **false**.
+    public var hasFeedback: Bool = false
+
+    /// A Boolean value that determines whether the button is in a loading state.
+    /// The **default** value is **false**. 
+    public var isLoading: Bool = false {
+        didSet {
+            self.viewModel.isLoading = self.isLoading
+            self.updateLoadingState()
+            self.updateContentForCurrentState()
+        }
+    }
+
+    /// A Boolean value indicating whether the control is in the enabled state.
+    public override var isEnabled: Bool {
+        didSet {
+            self.viewModel.isEnabled = self.isEnabled
+            self.updateContentForCurrentState()
+            self.accessibilityTraits(.notEnabled, condition: !self.isEnabled)
+        }
+    }
+
+    /// A Boolean value indicating whether the control is in the selected state.
+    public override var isSelected: Bool {
+        didSet {
+            self.updateContentForCurrentState()
+            self.accessibilityTraits(.selected, condition: self.isSelected)
+        }
+    }
+
+    /// A Boolean value indicating whether the control is in the highlighted state.
+    public override var isHighlighted: Bool {
+        didSet {
+            self.viewModel.isPressed = self.isHighlighted
+            self.updateContentForCurrentState()
+        }
+    }
+
+    public override var accessibilityLabel: String? {
+        get {
+            if let customAccessibilityLabel {
+                return customAccessibilityLabel
+            } else {
+                return self.titleLabel.accessibilityLabel
+            }
+        }
+        set {
+            self.customAccessibilityLabel = newValue
+        }
+    }
+
+    private let touchUpInsideSubject = PassthroughSubject<Void, Never>()
+    /// The publisher used to notify when user tap on button.
+    public private(set) lazy var touchUpInsidePublisher: AnyPublisher<Void, Never> = self.touchUpInsideSubject.eraseToAnyPublisher()
+
+    // MARK: - Private Properties
+
+    private let viewModel = ButtonViewModel()
+    private var subscriptions = Set<AnyCancellable>()
+
+    private var type: ButtonType = .button {
+        didSet {
+            self.viewModel.type = self.type
+        }
+    }
+
+    private var heightConstraint: NSLayoutConstraint?
+    private var widthConstraint: NSLayoutConstraint?
+    private var minWidthConstraint: NSLayoutConstraint?
+
+    @ScaledUIFrame private var height: CGFloat = 0
+    @ScaledUIFrame private var width: CGFloat = 0
+
+    @ScaledUIBorderRadius private var cornerRadius: CGFloat = 0
+    @ScaledUIBorderWidth private var borderWidth: CGFloat = 0
+
+    private var titles: [UInt: String] = [:]
+    private var attributedTitles: [UInt: NSAttributedString] = [:]
+    private var images: [UInt: UIImage] = [:]
+
+    private var customAccessibilityLabel: String?
+
+    // MARK: - Initialization
+
+    /// Creates a button with a theme and an optional custom style.
+    ///
+    /// - Parameter theme: The theme to apply to the button.
+    /// - Parameter style: A defined ``SparkUIButtonStyle`` (like uploadButton). Optional. Default is *nil*
+    ///
+    /// Implementation example :
+    ///
+    /// ### Text Only Button
+    ///
+    /// ```swift
+    /// let button = SparkUIButton(theme: theme)
+    /// button.setTitle("Click Me", for: .normal)
+    /// button.intent = .main
+    /// button.variant = .filled
+    /// button.size = .medium
+    /// button.addAction(UIAction { _ in
+    ///     // Your action
+    /// }, for: .touchUpInside)
+    /// ```
+    ///
+    /// ### Button with Icon
+    ///
+    /// ```swift
+    /// let button = SparkUIButton(theme: theme)
+    /// button.setTitle("Save", for: .normal)
+    /// button.setImage(UIImage(systemName: "checkmark"), for: .normal)
+    /// button.intent = .support
+    /// button.variant = .outlined
+    /// button.size = .medium
+    /// button.alignment = .leadingImage
+    /// ```
+    ///
+    /// ### Icon Button
+    ///
+    /// ```swift
+    /// let button = SparkUIButton(theme: theme)
+    /// button.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+    /// button.intent = .support
+    /// button.variant = .ghost
+    /// button.size = .small
+    /// ```
+    ///
+    /// ## Rendering
+    ///
+    /// ### Title
+    ///
+    /// ![Button rendering.](button_title.png)
+    ///
+    /// ### Icon only
+    ///
+    /// ![Button rendering.](button_icon.png)
+    ///
+    /// ### All content (image + title)
+    ///
+    /// ![Button rendering.](button_all.png)
+    public init(
+        theme: any Theme,
+        style: (any SparkUIButtonStyle)? = nil
+    ) {
+        self.theme = theme
+
+        super.init(frame: .zero)
+
+        style?.apply(on: self)
+
+        self.setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Setup
+
+    private func setupView() {
+        // Add subviews
+        self.addSubview(self.contentStackView)
+
+        // Update UI
+        self.updateAlignment()
+        self.updateLoadingState()
+
+        // Setup gesture
+        self.enableTouch()
+
+        // Setup constraints
+        self.setupConstraints()
+
+        // Setup accessibility
+        self.setupAccessibility()
+
+        // Setup action
+        self.setupAction()
+
+        // Setup subscriptions
+        self.setupSubscriptions()
+
+        // Setup view model
+        self.viewModel.setup(
+            theme: self.theme,
+            intent: self.intent,
+            variant: self.variant,
+            shape: self.shape,
+            size: self.size,
+            type: self.type,
+            contentVisibility: self.contentVisibility,
+            removeStyles: self.removeStyles,
+            isEnabled: self.isEnabled,
+            isLoading: self.isLoading
+        )
+    }
+
+    // MARK: - Layout
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+
+        self.updateBorder()
+    }
+
+    // MARK: - Constraints
+
+    private func setupConstraints() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        // Self constraints
+        self.heightConstraint = self.heightAnchor.constraint(equalToConstant: .zero)
+        self.widthConstraint = self.widthAnchor.constraint(equalTo: self.heightAnchor)
+        self.minWidthConstraint = self.widthAnchor.constraint(greaterThanOrEqualToConstant: .zero)
+
+        self.setupSpaceViewsConstraints()
+        self.setupContentStackViewConstraints()
+    }
+
+    private func setupSpaceViewsConstraints() {
+        self.spaceView1.translatesAutoresizingMaskIntoConstraints = false
+        self.spaceView2.translatesAutoresizingMaskIntoConstraints = false
+
+        self.spaceView1.widthAnchor.constraint(equalTo: self.spaceView2.widthAnchor).isActive = true
+    }
+
+    private func setupContentStackViewConstraints() {
+        self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.stickEdges(
+            from: self.contentStackView,
+            to: self
+        )
+    }
+
+    // MARK: - Accessibility
+
+    private func setupAccessibility() {
+        self.accessibilityIdentifier = ButtonAccessibilityIdentifier.button
+        self.accessibilityTraits = .button
+        self.isAccessibilityElement = true
+        self.scalesLargeContentImage = true
+        self.showsLargeContentViewer = true
+        self.addInteraction(UILargeContentViewerInteraction())
+        self.maximumContentSizeCategory = .extraExtraExtraLarge
+    }
+
+    // MARK: - Action
+
+    private func setupAction() {
+        self.addAction(.init(handler: { [weak self] _ in
+            guard let self else { return }
+
+            // Action
+            self.touchUpInsideSubject.send()
+
+            // Haptic
+            if self.hasFeedback {
+                let generator = UIImpactFeedbackGenerator(style: .light)
+                generator.impactOccurred()
+            }
+
+        }), for: .touchUpInside)
+    }
+
+    // MARK: - Update UI
+
+    private func updateAlignment() {
+        // Remove some arranged subviews first
+        self.contentStackView.removeArrangedSubviews([
+            self.titleLabel,
+            self._imageView
+        ])
+
+        // Insert new subviews before the latest current subviews
+        self.contentStackView.insertArrangedSubview(
+            self.alignment.isTrailingImage ? self.titleLabel : self._imageView,
+            at: self.contentStackView.arrangedSubviews.count - 1
+        )
+
+        self.contentStackView.insertArrangedSubview(
+            self.alignment.isTrailingImage ? self._imageView : self.titleLabel,
+            at: self.contentStackView.arrangedSubviews.count - 1
+        )
+    }
+
+    private func updateBorder(colors: ButtonColors? = nil) {
+        let colors = colors ?? self.viewModel.colors
+
+        self.sparkBorderRadius(
+            width: self.borderWidth,
+            radius: self.cornerRadius,
+            colorToken: colors.borderColor
+        )
+    }
+
+    private func updateColors(_ colors: ButtonColors? = nil) {
+        let colors = colors ?? self.viewModel.colors
+
+        self.backgroundColor = colors.backgroundColor.uiColor
+        self.titleLabel.textColor = colors.tintColor.uiColor
+        self._imageView.tintColor = colors.tintColor.uiColor
+        self.spinner.intent = .custom(colors.tintColor)
+    }
+
+    private func updateSize(_ sizes: ButtonSizes? = nil) {
+        let sizes = sizes ?? self.viewModel.sizes
+
+        // Height
+        self.heightConstraint?.constant = self.height
+        self.heightConstraint?.isActive = sizes.isFixedHeight
+
+        // Width
+        self.widthConstraint?.isActive = sizes.isFixedWidth
+        self.minWidthConstraint?.constant = self.width
+        self.minWidthConstraint?.isActive = true
+
+        self.setNeedsUpdateConstraints()
+    }
+
+    private func updateLayout(_ layout: ButtonLayout? = nil) {
+        let layout = layout ?? self.viewModel.layout
+
+        // Update stack view spacing
+        self.contentStackView.spacing = layout.horizontalSpacing
+
+        // Update content insets
+        self.contentStackView.directionalLayoutMargins = .init(
+            top: .zero,
+            leading: layout.horizontalPadding,
+            bottom: .zero,
+            trailing: layout.horizontalPadding
+        )
+        self.contentStackView.isLayoutMarginsRelativeArrangement = true
+    }
+
+    private func updateTitleFontToken(_ fontToken: (any TypographyFontToken)? = nil) {
+        let fontToken = fontToken ?? self.viewModel.titleFontToken
+
+        self.titleLabel.font = fontToken.uiFont
+    }
+
+    private func updateLoadingState() {
+        self.spinner.isHidden = !self.isLoading
+    }
+
+    private func updateContentForCurrentState(showContent: Bool? = nil) {
+        let showContent = showContent ?? self.viewModel.showContent
+
+        // Get the appropriate content for the current state
+        let currentTitle = self.titles.valueForCurrentState(on: self)
+        let currentAttributedTitle = self.attributedTitles.valueForCurrentState(on: self)
+        let currentImage = self.images.valueForCurrentState(on: self)
+
+        // Update the title label
+        if let currentAttributedTitle {
+            self.titleLabel.attributedText(currentAttributedTitle)
+        } else {
+            self.titleLabel.text(currentTitle)
+        }
+
+        // Update the image view
+        self._imageView.image = currentImage
+
+        // Update type based on new content
+        self.type = .init(
+            isTitle: self.currentTitle?.isEmpty == false,
+            isImage: self.currentImage != nil
+        )
+
+        // Accessibility
+        self.largeContentTitle = self.currentTitle
+        self.largeContentImage = self.currentImage
+
+        // Update the visibility
+        if showContent {
+            switch self.contentVisibility {
+            case .hideLabel: self.titleLabel.isHidden = true
+            case .hideImage: self._imageView.isHidden = true
+            default: break
+            }
+
+        } else {
+            self.titleLabel.isHidden = true
+            self._imageView.isHidden = true
+        }
+    }
+
+    // MARK: - Subscribe
+
+    private func setupSubscriptions() {
+        // Border
+        self.viewModel.$border.subscribe(in: &self.subscriptions) { [weak self] border in
+            guard let self else { return }
+
+            self._borderWidth = .init(
+                wrappedValue: border.width,
+                traitCollection: self.traitCollection
+            )
+
+            self._cornerRadius = .init(
+                wrappedValue: border.radius,
+                traitCollection: self.traitCollection
+            )
+            self.updateBorder()
+        }
+
+        // Colors
+        self.viewModel.$colors.subscribe(in: &self.subscriptions) { [weak self] colors in
+            guard let self else { return }
+
+            self.updateBorder(colors: colors)
+            self.updateColors(colors)
+        }
+
+        // Dim
+        self.viewModel.$dim.subscribe(in: &self.subscriptions) { [weak self] dim in
+            self?.alpha = dim
+        }
+
+        // Layout
+        self.viewModel.$layout.subscribe(in: &self.subscriptions) { [weak self] layout in
+            self?.updateLayout(layout)
+        }
+
+        // Title font token
+        self.viewModel.$titleFontToken.subscribe(in: &self.subscriptions) { [weak self] titleFontToken in
+            self?.updateTitleFontToken(titleFontToken)
+        }
+
+        // Sizes
+        self.viewModel.$sizes.subscribe(in: &self.subscriptions) { [weak self] sizes in
+            guard let self else { return }
+
+            self._height = .init(
+                wrappedValue: sizes.height,
+                traitCollection: self.traitCollection
+            )
+            self._width = .init(
+                wrappedValue: sizes.width,
+                traitCollection: self.traitCollection
+            )
+            self.updateSize(sizes)
+
+            self._imageView.updateImageSize(sizes.imageSize)
+        }
+
+        // Show content
+        self.viewModel.$showContent.subscribe(in: &self.subscriptions) { [weak self] showContent in
+            self?.updateContentForCurrentState(showContent: showContent)
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Sets the content visibility of the button with optional animation.
+    ///
+    /// This method allows you to control which parts of the button content are visible.
+    ///
+    /// When animated, the visibility changes are smoothly transitioned with a fade effect.
+    ///
+    /// - Parameters:
+    ///   - contentVisibility: The desired content visibility state. See ``ButtonContentVisibility`` for available options.
+    ///   - animated: Whether to animate the visibility change. When `true`, content fades in/out smoothly.
+    ///
+    /// - Note: If the new content visibility is the same as the current one, this method does nothing.
+    public func setContentVisibility(_ contentVisibility: ButtonContentVisibility, animated: Bool) {
+        guard contentVisibility != self.contentVisibility else {
+            return
+        }
+
+        if animated {
+            self._imageView.updateAlpha(
+                currentContentVisibility: self.contentVisibility,
+                newContentVisibility: contentVisibility,
+                onAnimation: false
+            )
+
+            self.titleLabel.updateAlpha(
+                currentContentVisibility: self.contentVisibility,
+                newContentVisibility: contentVisibility,
+                onAnimation: false
+            )
+
+            UIView.optionalAnimate(withDuration: ButtonConstants.Animation.slowDuration) {
+
+                self._imageView.updateAlpha(
+                    currentContentVisibility: self.contentVisibility,
+                    newContentVisibility: contentVisibility,
+                    onAnimation: true
+                )
+
+                self.titleLabel.updateAlpha(
+                    currentContentVisibility: self.contentVisibility,
+                    newContentVisibility: contentVisibility,
+                    onAnimation: true
+                )
+
+                self.contentVisibility = contentVisibility
+            }
+
+        } else {
+            self.contentVisibility = contentVisibility
+        }
+    }
+
+    /// Sets the title for the button for the specified state.
+    ///
+    /// - Parameters:
+    ///   - title: The title to set.
+    ///   - state: The control state (.normal, .selected, .disabled, .highlighted).
+    public func setTitle(_ title: String?, for state: UIControl.State) {
+        if self.titles.setValue(title, for: state) {
+            // Remove the attributed title if the value was setted.
+            self.attributedTitles.removeValue(for: state)
+        }
+        self.updateContentForCurrentState()
+    }
+
+    /// Sets the attributed title for the button for the specified state.
+    ///
+    /// - Parameters:
+    ///   - attributedTitle: The attributed title to set.
+    ///   - state: The control state (.normal, .selected, .disabled, .highlighted).
+    public func setAttributedTitle(_ attributedTitle: NSAttributedString?, for state: UIControl.State) {
+        if self.attributedTitles.setValue(attributedTitle, for: state) {
+            // Remove the title if the value was setted.
+            self.titles.removeValue(for: state)
+        }
+
+        self.updateContentForCurrentState()
+    }
+
+    /// Sets the image for the button for the specified state.
+    ///
+    /// - Parameters:
+    ///   - image: The image to set.
+    ///   - state: The control state (.normal, .selected, .disabled, .highlighted).
+    public func setImage(_ image: UIImage?, for state: UIControl.State) {
+        self.images.setValue(image, for: state)
+
+        self.updateContentForCurrentState()
+    }
+
+    /// Returns the title for the specified state.
+    ///
+    /// - Parameter state: The control state (.normal, .selected, .disabled, .highlighted).
+    /// - Returns: The title string, or nil if no title is set for that state.
+    public func title(for state: UIControl.State) -> String? {
+        return self.titles.value(for: state)
+    }
+
+    /// Returns the attributed title for the specified state.
+    ///
+    /// - Parameter state: The control state (.normal, .selected, .disabled, .highlighted).
+    /// - Returns: The attributed title, or nil if no attributed title is set for that state.
+    public func attributedTitle(for state: UIControl.State) -> NSAttributedString? {
+        return self.attributedTitles.value(for: state)
+    }
+
+    /// Returns the image for the specified state.
+    ///
+    /// - Parameter state: The control state (.normal, .selected, .disabled, .highlighted).
+    /// - Returns: The image, or nil if no image is set for that state.
+    public func image(for state: UIControl.State) -> UIImage? {
+        return self.images.value(for: state)
+    }
+
+    /// Returns the current title being displayed.
+    public var currentTitle: String? {
+        return self.titleLabel.text
+    }
+
+    /// Returns the current attributed title being displayed.
+    public var currentAttributedTitle: NSAttributedString? {
+        return self.titleLabel.attributedText
+    }
+
+    /// Returns the current image being displayed.
+    public var currentImage: UIImage? {
+        return self._imageView.image
+    }
+
+    // MARK: - Trait Collection
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // Sizes
+        self._height.update(traitCollection: self.traitCollection)
+        self._width.update(traitCollection: self.traitCollection)
+        self.updateSize()
+
+        // Corner
+        self._cornerRadius.update(traitCollection: self.traitCollection)
+        self._borderWidth.update(traitCollection: self.traitCollection)
+        self.updateBorder()
+    }
+}
+
+// MARK: - Extension
+
+private extension UIView {
+
+    func updateAlpha(
+        currentContentVisibility: ButtonContentVisibility,
+        newContentVisibility: ButtonContentVisibility,
+        onAnimation: Bool
+    ) {
+        let isLabel = self is UILabel
+
+        let currentShowContent = isLabel ? currentContentVisibility.showLabel : currentContentVisibility.showImage
+        let newShowContent = isLabel ? newContentVisibility.showLabel : newContentVisibility.showImage
+
+        if currentShowContent != newShowContent {
+            if onAnimation {
+                self.alpha = newShowContent ? 1 : 0
+            } else { // Before the animation
+                self.alpha = newShowContent ? 0 : 1
+            }
+        }
+    }
+}

--- a/Sources/Core/View/UIKit/Style/SparkUIButtonStyle.swift
+++ b/Sources/Core/View/UIKit/Style/SparkUIButtonStyle.swift
@@ -1,0 +1,22 @@
+//
+//  SparkUIButtonStyle.swift
+//  SparkComponentButton
+//
+//  Created by robin.lemaire on 20/03/2026.
+//  Copyright © 2026 Leboncoin. All rights reserved.
+//
+
+/// A protocol that defines the visual appearance of a ``SparkUIButton``.
+///
+/// Conform to this protocol to create custom button styles that modify only the design
+/// and visual presentation of Spark buttons without altering their behavior or functionality.
+///
+/// Use the `init` with *style* parameter to apply your custom style to a button:
+///
+/// ```swift
+/// let button = SparkUIButton(theme: theme, style: MyCustomButtonStyle())
+/// ```
+public protocol SparkUIButtonStyle {
+    /// Apply the style on the button passed in parameter.
+    func apply(on button: SparkUIButton)
+}


### PR DESCRIPTION
Implement the new button view architecture:
- SwiftUI SparkButton with comprehensive init extensions for all use cases
- SwiftUI menu button support with native Menu integration
- UIKit SparkUIButton with modern styling system
- SparkButtonImage component for custom image rendering
- Button style protocols for both SwiftUI and UIKit
- Internal components for UIKit (spinner, image view)