### PR TITLE
fix: replace NSLayoutConstraint.stickEdges with explicit constraints in SparkUIButton

### DIFF
--- a/Sources/Core/View/UIKit/SparkUIButton.swift
+++ b/Sources/Core/View/UIKit/SparkUIButton.swift
@@ -298,6 +298,8 @@ public final class SparkUIButton: UIControl {
     @ScaledUIBorderRadius private var cornerRadius: CGFloat = 0
     @ScaledUIBorderWidth private var borderWidth: CGFloat = 0
 
+    private var contentStackViewLeadingConstraint: NSLayoutConstraint?
+
     private var titles: [UInt: String] = [:]
     private var attributedTitles: [UInt: NSAttributedString] = [:]
     private var images: [UInt: UIImage] = [:]
@@ -450,10 +452,17 @@ public final class SparkUIButton: UIControl {
     private func setupContentStackViewConstraints() {
         self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.stickEdges(
-            from: self.contentStackView,
-            to: self
-        )
+        self.contentStackViewLeadingConstraint = self.contentStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+        let contentStackViewTopConstraint = self.contentStackView.topAnchor.constraint(equalTo: self.topAnchor)
+        let contentStackViewCenterYAnchor = self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        let contentStackViewCenterXAnchor = self.contentStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+
+        NSLayoutConstraint.activate([
+            self.contentStackViewLeadingConstraint,
+            contentStackViewTopConstraint,
+            contentStackViewCenterYAnchor,
+            contentStackViewCenterXAnchor,
+        ].compactMap { $0 })
     }
 
     // MARK: - Accessibility
@@ -546,13 +555,7 @@ public final class SparkUIButton: UIControl {
         self.subContentStackView.spacing = layout.horizontalSpacing
 
         // Update content insets
-        self.subContentStackView.directionalLayoutMargins = .init(
-            top: .zero,
-            leading: layout.horizontalPadding,
-            bottom: .zero,
-            trailing: layout.horizontalPadding
-        )
-        self.subContentStackView.isLayoutMarginsRelativeArrangement = true
+        self.contentStackViewLeadingConstraint?.constant = layout.horizontalPadding
     }
 
     private func updateTitleFontToken(_ fontToken: (any TypographyFontToken)? = nil) {


### PR DESCRIPTION
- Add contentStackViewLeadingConstraint property to manage leading spacing dynamically
- Replace NSLayoutConstraint.stickEdges helper with explicit constraint setup using leadingAnchor, topAnchor, centerYAnchor, and centerXAnchor
- Update layout logic to modify leading constraint constant instead of using directionalLayoutMargins on subContentStackView
- Remove isLayoutMarginsRelativeArrangement approach in favor of direct constraint manipulation

This change provides more explicit control over the button's internal layout constraints and simplifies the horizontal padding implementation.